### PR TITLE
Swerve module recommendations

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -29,9 +29,7 @@ public final class Constants {
     public static final double DRIVE_GEAR_RATIO = 1.d / 6.75d;
 
     public static final double DRIVE_ROTATION_TO_METER = DRIVE_GEAR_RATIO * Math.PI * WHEEL_DIAMETER;
-    public static final double STEER_ROTATION_TO_RADIANS = STEERING_GEAR_RATIO * Math.PI * 2d;
-    public static final double DRIVE_METERS_PER_MINUTE = DRIVE_ROTATION_TO_METER / 60d;
-    public static final double STEER_RADIANS_PER_MINUTE = STEER_ROTATION_TO_RADIANS / 60d;
+    public static final double DRIVE_METERS_PER_SECOND = DRIVE_ROTATION_TO_METER / 60d / 60d;
 
     // Actual drive gains
     // public static final double MODULE_KP = 0.5;


### PR DESCRIPTION
- Speed should be in meters per second, not meters per minute. This seems to be the way `DriveCommand` expects it, but the constant made it seem like the module was using meters per minute.
- Internally to the `SwerveModule` class, Swerve module steer position should be in rotations with a range of [-0.5, 0.5). This is the unit the CANCoder and Spark Max use. External to the `SwerveModule`, use radians [-Pi, Pi).
- Use closed loop on the Spark Max motor controller, not a `PIDController` on the roboRIO. There are several reason you probably want to do this:
  - You pay big money for smart motor controllers, so use them.
  - On the motor controller the encoder value is read directly, it doesn't have to come over the CAN network first.
  - Motor controller closed loop runs at 1000Hz where the roboRIO only runs at 50hz.
- Let the motors and encoders handle your offsets and inversions. Configure them once, and let them handle the math.
- Use the CANCoders `waitForUpdate()` function when getting it's absolute position on startup. This is a key part of the fix for the issue where a wheel is out of alignment.