### PR TITLE
Drive and estimate pose with WPILib coordinates

### DIFF
--- a/src/main/java/frc/robot/commands/DriveCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCommand.java
@@ -1,11 +1,15 @@
 package frc.robot.commands;
 
+import static edu.wpi.first.math.MathUtil.applyDeadband;
+import static edu.wpi.first.math.MathUtil.clamp;
+
 import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.Constants.DrivetrainConstants;
 import frc.robot.subsystems.DrivetrainSubsystem;
@@ -35,10 +39,6 @@ public class DriveCommand extends CommandBase {
         addRequirements(drivetrainSubsystem);
     }
 
-    double clamp(double v, double mi, double ma) {
-        return (v < mi) ? mi : (v > ma ? ma : v);
-    }
-
     public Translation2d DeadBand(Translation2d input, double deadzone) {
         double mag = input.getNorm();
         Translation2d norm = input.div(mag);
@@ -54,19 +54,15 @@ public class DriveCommand extends CommandBase {
         }
     }
 
-    public double DeadBand(double input, double deadband) {
-        return Math.abs(input) < deadband ? 0.0 : (input - Math.signum(input) * deadband) / (1.0 - deadband);
-    }
-
     @Override
     public void execute() {
-        Translation2d xyRaw = new Translation2d(xbox.getLeftX(), xbox.getLeftY());
+        Translation2d xyRaw = new Translation2d(-xbox.getLeftY(), -xbox.getLeftX());
         Translation2d xySpeed = DeadBand(xyRaw, 0.15);
-        double zSpeed = DeadBand(xbox.getRightX(), 0.1);
+        double zSpeed = applyDeadband(-xbox.getRightX(), 0.1);
         double xSpeed = xySpeed.getX(); // xbox.getLeftX();
         double ySpeed = xySpeed.getY(); // xbox.getLeftY();
 
-        System.out.println(xySpeed.getNorm());
+        SmartDashboard.putNumber("xySpeed norm", xySpeed.getNorm());
 
         // double mag_xy = Math.sqrt(xSpeed*xSpeed + ySpeed*ySpeed);
 


### PR DESCRIPTION
This is your intended drive scheme:
- Robot movement to the left is +Y on the field, but -X on the left controller stick
- Robot movement forward is +X on the field, but -Y on the left controller stick
- Robot rotation is +left on the field, but -X on the right controller stick

Based on this scheme, the `DriveCommand` needed adjustment:
- All of the axes need to be inverted.
- The correct controller sticks need to be controlling the correct translation components.
- Also, never use `System.out.println()` within the robot loop. It will flood the console to the point of lagging your robot. Use the SmartDashboard/NetworkTables to send the value to the driver station.

The following fixes were needed in `DrivetrainSubsystem`:
- The NAVX gyro angle needs to be inverted. NavX's `getAngle()` returns the heading with clockwise positive, which is backwards from WPILib. 
- When you zero the heading, you need to reset odometry. I assume the intent is that the robot's current heading becomes zero, but the robot's estimated translation stays the same.
- I deleted a couple incorrect methods that weren't being used: `setChassisSpeedsAUTO()` and `setHeading()`