### PR TITLE
Working on practice field

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -25,7 +25,7 @@ public final class Constants {
 
   public static final class DrivetrainConstants {
     public static final double WHEEL_DIAMETER = Units.inchesToMeters(4);
-    public static final double STEERING_GEAR_RATIO = 1.d / (150d / 7d);
+    public static final double STEERING_GEAR_RATIO = (14.0 / 50.0) * (10.0 / 60.0);
     public static final double DRIVE_GEAR_RATIO = 1.d / 6.75d;
 
     public static final double DRIVE_ROTATION_TO_METER = DRIVE_GEAR_RATIO * Math.PI * WHEEL_DIAMETER;
@@ -43,33 +43,37 @@ public final class Constants {
     public static final int FL_DRIVE_ID = 2;
     public static final int FL_STEER_ID = 1;
     public static final int FL_ABSOLUTE_ENCODER_PORT = 1;
-    public static final double FL_OFFSET_RADIANS = Units.degreesToRadians(26.543) + Math.PI * 0.5d;
-    public static final boolean FL_ABSOLUTE_ENCODER_REVERSED = true;
-    public static final boolean FL_MOTOR_REVERSED = false;
+    public static final double FL_OFFSET_ROTATIONS = -0.073730;
+    public static final boolean FL_ABSOLUTE_ENCODER_REVERSED = false;
+    public static final boolean FL_DRIVE_MOTOR_REVERSED = true;
+    public static final boolean FL_STEER_MOTOR_REVERSED = true;
 
     // --------- Front Right Module --------- \\
     public static final int FR_DRIVE_ID = 4;
     public static final int FR_STEER_ID = 3;
     public static final int FR_ABSOLUTE_ENCODER_PORT = 4;
-    public static final double FR_OFFSET_RADIANS = Units.degreesToRadians(336.621) + Math.PI * 0.5d;
-    public static final boolean FR_ABSOLUTE_ENCODER_REVERSED = true;
-    public static final boolean FR_MOTOR_REVERSED = false;
+    public static final double FR_OFFSET_ROTATIONS = -0.935547;
+    public static final boolean FR_ABSOLUTE_ENCODER_REVERSED = false;
+    public static final boolean FR_DRIVE_MOTOR_REVERSED = true;
+    public static final boolean FR_STEER_MOTOR_REVERSED = true;
 
     // --------- Back Right Module --------- \\
     public static final int BR_DRIVE_ID = 6;
     public static final int BR_STEER_ID = 5;
     public static final int BR_ABSOLUTE_ENCODER_PORT = 2;
-    public static final double BR_OFFSET_RADIANS = Units.degreesToRadians(54.404) + Math.PI * 0.5d;
-    public static final boolean BR_ABSOLUTE_ENCODER_REVERSED = true;
-    public static final boolean BR_MOTOR_REVERSED = false;
+    public static final double BR_OFFSET_ROTATIONS = -0.150879;
+    public static final boolean BR_ABSOLUTE_ENCODER_REVERSED = false;
+    public static final boolean BR_DRIVE_MOTOR_REVERSED = true;
+    public static final boolean BR_STEER_MOTOR_REVERSED = true;
 
     // --------- Back Left Module --------- \\
     public static final int BL_DRIVE_ID = 8;
     public static final int BL_STEER_ID = 7;
     public static final int BL_ABSOLUTE_ENCODER_PORT = 3;
-    public static final double BL_OFFSET_RADIANS = Units.degreesToRadians(320.801) + Math.PI * 0.5d;
-    public static final boolean BL_ABSOLUTE_ENCODER_REVERSED = true;
-    public static final boolean BL_MOTOR_REVERSED = false;
+    public static final double BL_OFFSET_ROTATIONS = -0.888916;
+    public static final boolean BL_ABSOLUTE_ENCODER_REVERSED = false;
+    public static final boolean BL_DRIVE_MOTOR_REVERSED = true;
+    public static final boolean BL_STEER_MOTOR_REVERSED = true;
 
     public static final double MAX_MODULE_VELOCITY = 4.8;
     public static final double MAX_ROBOT_VELOCITY = 4.8;
@@ -80,10 +84,10 @@ public final class Constants {
     public static final double WHEEL_BASE = Units.inchesToMeters(18.75);
 
     public static final SwerveDriveKinematics KINEMATICS = new SwerveDriveKinematics(
-        new Translation2d(TRACK_WIDTH / 2.0, WHEEL_BASE / 2.0),
-        new Translation2d(TRACK_WIDTH / 2.0, -WHEEL_BASE / 2.0),
-        new Translation2d(-TRACK_WIDTH / 2.0, WHEEL_BASE / 2.0),
-        new Translation2d(-TRACK_WIDTH / 2.0, -WHEEL_BASE / 2.0));
+        new Translation2d(-TRACK_WIDTH / 2.0, -WHEEL_BASE / 2.0), // Back Right
+        new Translation2d(TRACK_WIDTH / 2.0, -WHEEL_BASE / 2.0), // Front Right
+        new Translation2d(-TRACK_WIDTH / 2.0, WHEEL_BASE / 2.0), // Back Left
+        new Translation2d(TRACK_WIDTH / 2.0, WHEEL_BASE / 2.0)); // Front left
 
     public static final double XY_SPEED_LIMIT = 0.8;
     public static final double Z_SPEED_LIMIT = 1.0;

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -19,24 +19,24 @@ import frc.swerve.SwerveModule;
 
 public class DrivetrainSubsystem extends SubsystemBase {
     private final SwerveModule frontLeft = new SwerveModule(DrivetrainConstants.FL_STEER_ID, DrivetrainConstants.FL_DRIVE_ID,
-            DrivetrainConstants.FL_ABSOLUTE_ENCODER_PORT, DrivetrainConstants.FL_OFFSET_RADIANS,
+            DrivetrainConstants.FL_ABSOLUTE_ENCODER_PORT, DrivetrainConstants.FL_OFFSET_ROTATIONS,
             DrivetrainConstants.FL_ABSOLUTE_ENCODER_REVERSED,
-            DrivetrainConstants.FL_MOTOR_REVERSED);
+            DrivetrainConstants.FL_DRIVE_MOTOR_REVERSED, DrivetrainConstants.FL_STEER_MOTOR_REVERSED);
 
     private final SwerveModule frontRight = new SwerveModule(DrivetrainConstants.FR_STEER_ID, DrivetrainConstants.FR_DRIVE_ID,
-            DrivetrainConstants.FR_ABSOLUTE_ENCODER_PORT, DrivetrainConstants.FR_OFFSET_RADIANS,
+            DrivetrainConstants.FR_ABSOLUTE_ENCODER_PORT, DrivetrainConstants.FR_OFFSET_ROTATIONS,
             DrivetrainConstants.FR_ABSOLUTE_ENCODER_REVERSED,
-            DrivetrainConstants.FR_MOTOR_REVERSED);
+            DrivetrainConstants.FR_DRIVE_MOTOR_REVERSED, DrivetrainConstants.FR_STEER_MOTOR_REVERSED);
 
     private final SwerveModule backRight = new SwerveModule(DrivetrainConstants.BR_STEER_ID, DrivetrainConstants.BR_DRIVE_ID,
-            DrivetrainConstants.BR_ABSOLUTE_ENCODER_PORT, DrivetrainConstants.BR_OFFSET_RADIANS,
+            DrivetrainConstants.BR_ABSOLUTE_ENCODER_PORT, DrivetrainConstants.BR_OFFSET_ROTATIONS,
             DrivetrainConstants.BR_ABSOLUTE_ENCODER_REVERSED,
-            DrivetrainConstants.BR_MOTOR_REVERSED);
+            DrivetrainConstants.BR_DRIVE_MOTOR_REVERSED, DrivetrainConstants.BR_STEER_MOTOR_REVERSED);
 
     private final SwerveModule backLeft = new SwerveModule(DrivetrainConstants.BL_STEER_ID, DrivetrainConstants.BL_DRIVE_ID,
-            DrivetrainConstants.BL_ABSOLUTE_ENCODER_PORT, DrivetrainConstants.BL_OFFSET_RADIANS,
+            DrivetrainConstants.BL_ABSOLUTE_ENCODER_PORT, DrivetrainConstants.BL_OFFSET_ROTATIONS,
             DrivetrainConstants.BL_ABSOLUTE_ENCODER_REVERSED,
-            DrivetrainConstants.BL_MOTOR_REVERSED);
+            DrivetrainConstants.BL_DRIVE_MOTOR_REVERSED, DrivetrainConstants.BL_STEER_MOTOR_REVERSED);
 
     private final AHRS navX = new AHRS(SPI.Port.kMXP);
 
@@ -112,10 +112,10 @@ public class DrivetrainSubsystem extends SubsystemBase {
     public void setModules(SwerveModuleState[] states) {
         // Normalize speeds so they are all obtainable
         SwerveDriveKinematics.desaturateWheelSpeeds(states, DrivetrainConstants.MAX_MODULE_VELOCITY);
-        frontLeft.setModuleState(states[3]);
+        backRight.setModuleState(states[0]);
         frontRight.setModuleState(states[1]);
         backLeft.setModuleState(states[2]);
-        backRight.setModuleState(states[0]);
+        frontLeft.setModuleState(states[3]);
     }
 
     public void setXstance() {
@@ -135,10 +135,10 @@ public class DrivetrainSubsystem extends SubsystemBase {
 
     public SwerveModulePosition[] getModulePositions() {
         SwerveModulePosition[] states = new SwerveModulePosition[4];
-        states[3] = frontLeft.getModulePosition();
+        states[0] = backRight.getModulePosition();
         states[1] = frontRight.getModulePosition();
         states[2] = backLeft.getModulePosition();
-        states[0] = backRight.getModulePosition();
+        states[3] = frontLeft.getModulePosition();
 
         return states;
     }

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -126,9 +126,11 @@ public class DrivetrainSubsystem extends SubsystemBase {
     }
 
     public ChassisSpeeds getChassisSpeeds() {
-        ChassisSpeeds speeds = DrivetrainConstants.KINEMATICS.toChassisSpeeds(frontLeft.getModuleState(),
-                frontRight.getModuleState(),
-                backLeft.getModuleState(), backRight.getModuleState());
+        ChassisSpeeds speeds = DrivetrainConstants.KINEMATICS.toChassisSpeeds(
+            backRight.getModuleState(),
+            frontRight.getModuleState(),
+            backLeft.getModuleState(),
+            frontLeft.getModuleState());
 
         return speeds;
     }

--- a/src/main/java/frc/swerve/SwerveModule.java
+++ b/src/main/java/frc/swerve/SwerveModule.java
@@ -14,7 +14,6 @@ import com.revrobotics.SparkMaxPIDController;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
-import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants.DrivetrainConstants;
 
@@ -31,16 +30,19 @@ public class SwerveModule {
 
     private final SparkMaxPIDController steerPID;
 
-    private int thisModuleNumber;
+    private final int thisModuleNumber;
 
-    public SwerveModule(int steerCanID, int driveCanID, int absoluteEncoderPort, double motorOffsetRadians,
-            boolean isAbsoluteEncoderReversed, boolean motorReversed) {
+    public SwerveModule(int steerCanID, int driveCanID, int absoluteEncoderPort, double encoderOffsetRotations,
+            boolean isAbsoluteEncoderReversed, boolean driveMotorInverted, boolean steerMotorInverted) {
         driveMotor = new CANSparkMax(driveCanID, MotorType.kBrushless);
-        driveMotor.setInverted(false);
+        driveMotor.restoreFactoryDefaults();
+        driveMotor.setInverted(driveMotorInverted);
         driveMotor.setIdleMode(IdleMode.kBrake);
+
         steerMotor = new CANSparkMax(steerCanID, MotorType.kBrushless);
+        steerMotor.restoreFactoryDefaults();
         steerMotor.setIdleMode(IdleMode.kBrake);
-        steerMotor.setInverted(false);
+        steerMotor.setInverted(steerMotorInverted);
 
         driveMotorEncoder = driveMotor.getEncoder();
         steerMotorEncoder = steerMotor.getEncoder();
@@ -48,8 +50,8 @@ public class SwerveModule {
         absoluteEncoder = new CANcoder(absoluteEncoderPort);
         CANcoderConfiguration canCoderConfig = new CANcoderConfiguration();
         // Set the CANCoder magnetic offset. This is the inverse of the ROTATIONS the sensor reads when the wheel is pointed straight forward.
-        canCoderConfig.MagnetSensor.MagnetOffset = Units.radiansToRotations(motorOffsetRadians);
-        // Set CANCoder to return direction from [-.5, .5) - straight forward should be 0
+        canCoderConfig.MagnetSensor.MagnetOffset = encoderOffsetRotations;
+        // Set CANCoder to return direction from [-0.5, 0.5) - straight forward should be 0
         canCoderConfig.MagnetSensor.AbsoluteSensorRange = AbsoluteSensorRangeValue.Signed_PlusMinusHalf;
         // Set the CANCoder phase / direction
         canCoderConfig.MagnetSensor.SensorDirection =
@@ -61,6 +63,7 @@ public class SwerveModule {
         driveMotorEncoder.setPositionConversionFactor(DrivetrainConstants.DRIVE_ROTATION_TO_METER);
         // Drive velocity in meters per second
         driveMotorEncoder.setVelocityConversionFactor(DrivetrainConstants.DRIVE_METERS_PER_SECOND);
+        driveMotor.burnFlash();
 
         // Steer position in rotations
         steerMotorEncoder.setPositionConversionFactor(DrivetrainConstants.STEERING_GEAR_RATIO);
@@ -71,6 +74,7 @@ public class SwerveModule {
         steerPID.setPositionPIDWrappingEnabled(true);
         steerPID.setPositionPIDWrappingMaxInput(0.5);
         steerPID.setPositionPIDWrappingMinInput(-0.5);
+        steerMotor.burnFlash();
 
         thisModuleNumber = moduleNumber;
         moduleNumber++;
@@ -86,8 +90,13 @@ public class SwerveModule {
         return driveMotorEncoder.getVelocity();
     }
 
-    public double getSteerPosition() {
-        return steerMotorEncoder.getPosition();
+    /**
+     * Get steer position
+     * @return steer position in range [-Pi, Pi) radians
+     */
+    public Rotation2d getSteerPosition() {
+        var rotations = steerMotorEncoder.getPosition();
+        return Rotation2d.fromRotations(rotations);
     }
 
     public double getSteerVelocity() {
@@ -96,27 +105,27 @@ public class SwerveModule {
 
     /**
      * Gets the absolute encoder (CANCoder) position
-     * @return position in rotations [0, 1)
+     * @return position in rotations [-0.5, 0.5)
      */
     private double getAbsoluteEncoderPosition() {
-        return absoluteEncoder.getAbsolutePosition().waitForUpdate(0.2).getValue();
+        return absoluteEncoder.getAbsolutePosition().waitForUpdate(0.4).getValue();
     }
 
     private void resetEncoders() {
         driveMotorEncoder.setPosition(0);
-        steerMotorEncoder.setPosition(Units.rotationsToRadians(getAbsoluteEncoderPosition()));
+        steerMotorEncoder.setPosition(getAbsoluteEncoderPosition());
     }
 
     public SwerveModuleState getModuleState() {
-        return new SwerveModuleState(getDriveVelocity(), new Rotation2d(getSteerPosition()));
+        return new SwerveModuleState(getDriveVelocity(), getSteerPosition());
     }
 
     public SwerveModulePosition getModulePosition() {
-        return new SwerveModulePosition(getDrivePosition(), new Rotation2d(getSteerPosition()));
+        return new SwerveModulePosition(getDrivePosition(), getSteerPosition());
     }
 
     public void setModuleStateRaw(SwerveModuleState state) {
-        state = SwerveModuleState.optimize(state, new Rotation2d(getSteerPosition()));
+        state = SwerveModuleState.optimize(state, getSteerPosition());
         double drive_command = state.speedMetersPerSecond / DrivetrainConstants.MAX_MODULE_VELOCITY;
         driveMotor.set(drive_command);
         steerPID.setReference(state.angle.getRotations(), ControlType.kPosition);


### PR DESCRIPTION
- Set offsets in rotations (avoiding conversion from degrees to radians to rotations.) There was also some math going on to rotate them by pi/2 radians, so we just started with values from Phoenix Tuner X.
- Set CANCoder absolute encoder `SensorDirection` to `CounterClockwise_Positive`
- Set Drive and Steer motor inversion (so positive output is forward drive and counter-clockwise steer)
- Correct `SwerveDriveKinemetics`. Forward is +X, left is +Y
  - BR is (-, -)
  - FR is (+, -)
  - BL is (-, +)
  - FL is (+, +)
- Correct conversion from CANCoder position to steer motor encoder position. It was incorrectly converting from rotations to radians, but both are rotations.
- Return steer position in a `Rotation2d` object from `getSteerPosition()` so the units are always clear (and since all uses of the method are creating `Rotation2d` anyway.)
- Implement Spark Max configuration best practice:
  - Call `restoreFactoryDefaults()` before configuring to clear out any existing configuration. This is important so no old values stick around in the settings we are not explicitally configuring.
  - Call `burnFlash()` after configuration so the settings persist across power cycle. This is important in case your motor controller has a power glitch during a match, since configuration only happens when the robot program starts.